### PR TITLE
Update package.json to include types in exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": {
+      "import": "./dist/esm/index.d.ts",
+      "require": "./dist/cjs/index.d.ts"
+    },
     "import": "./dist/esm/index.mjs",
     "require": "./dist/cjs/index.js"
   },


### PR DESCRIPTION
Issue: could find types
Fix: add to exports under `types`, as per these [docs](https://nodejs.org/api/packages.html#community-conditions-definitions). 